### PR TITLE
Optimize ft_strcspn by removing redundant loop

### DIFF
--- a/-- EXAMS/ExamRank2/Level 2/ft_strcspn.c
+++ b/-- EXAMS/ExamRank2/Level 2/ft_strcspn.c
@@ -6,7 +6,7 @@
 /*   By: brisly <brisly@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/16 16:52:57 by brisly            #+#    #+#             */
-/*   Updated: 2022/12/18 21:36:06 by brisly           ###   ########.fr       */
+/*   Updated: 2024/11/12 20:02:09 by fnicolau         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,9 +29,6 @@ size_t	ft_strcspn(const char *s, const char *reject)
 		}
 		i++;
 	}
-	i = 0;
-	while (s[i])
-		i++;
 	return (i);
 }
 


### PR DESCRIPTION
Firstly, thank you so much for your great job on this repo, your [site](https://42-cursus.gitbook.io) is amazing and very good in terms of code, navigating and so on, I really loved it 🤩.

This PR improves the **ft_strcspn** function by removing an unnecessary loop that recalculates the length of **s** at the end of the function. The **while** loop has been removed, as **i** already tracks the length of **s** in cases where no character from **reject** is found.