### PR TITLE
Enhance ft_strpbrk with NULL check and correct pointer return

### DIFF
--- a/-- EXAMS/ExamRank2/Level 2/ft_strpbrk.c
+++ b/-- EXAMS/ExamRank2/Level 2/ft_strpbrk.c
@@ -6,14 +6,19 @@
 /*   By: lfabbian <lfabbian@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/18 10:24:44 by lfabbian          #+#    #+#             */
-/*   Updated: 2022/12/18 10:39:04 by lfabbian         ###   ########.fr       */
+/*   Updated: 2024/11/13 07:15:52 by fnicolau         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
+
+#include <stdio.h>
 
 char	*ft_strpbrk(const char *s1, const char *s2)
 {
 	int i;
 	int	j;
+
+	if (!s1 || !s2)
+		return (NULL);
 
 	i = 0;
 	while (s1[i])
@@ -22,10 +27,26 @@ char	*ft_strpbrk(const char *s1, const char *s2)
 		while (s2[j])
 		{
 			if (s2[j] == s1[i])
-				return (s1[i]);
+				return ((char *)&s1[i]);
 			j++;
 		}
 		i++;
 	}
 	return (NULL);
 }
+
+int main(void)
+{
+    const char *str1 = "Hello, World!";
+    const char *str2 = ",";
+
+    char *result = ft_strpbrk(str1, str2);
+
+    if (result)
+        printf("First matching character: '%c' at position %li\n", *result, result - str1);
+    else
+        printf("No matching characters found.\n");
+
+    return 0;
+}
+


### PR DESCRIPTION
This pull request improves the **ft_strpbrk** function in two ways:    

1. **NULL Check**: Adds a **NULL** check at the beginning of **ft_strpbrk** to safely return **NULL** if either **s1** or **s2** is **NULL**.

2. **Correct Return Type**: Modifies the return statement to correctly return a pointer to the first matching character in **s1**, aligning with the function’s expected behavior.

**Impact**: These changes increase the reliability and correctness of **ft_strpbrk**. The function now safely handles **NULL** inputs and correctly returns a pointer to the first matching character, as expected in the standard **strpbrk** functionality. This should prevent unexpected crashes and provide accurate results in a wider range of cases.